### PR TITLE
Makes phone number clickable links

### DIFF
--- a/src/xebia_email_signature/templates/signature.html.jinja
+++ b/src/xebia_email_signature/templates/signature.html.jinja
@@ -121,9 +121,10 @@
                   font-size: 10pt;
                   line-height: 12pt;
                   font-style: normal;
+                  
                   margin: 0.1px;
                 ">
-                {{ data["formatted_phone"] | e}}
+                <a style="color: #5a5a5a;" href="callto:{{ data["formatted_phone"] | e}}">{{ data["formatted_phone"] | e}}</a>
               </p>
             </td>
           </tr>

--- a/src/xebia_email_signature/templates/signature.html.jinja
+++ b/src/xebia_email_signature/templates/signature.html.jinja
@@ -121,7 +121,6 @@
                   font-size: 10pt;
                   line-height: 12pt;
                   font-style: normal;
-                  
                   margin: 0.1px;
                 ">
                 <a style="color: #5a5a5a;" href="callto:{{ data["formatted_phone"] | e}}">{{ data["formatted_phone"] | e}}</a>

--- a/src/xebia_email_signature/templates/signature.html.jinja
+++ b/src/xebia_email_signature/templates/signature.html.jinja
@@ -123,7 +123,7 @@
                   font-style: normal;
                   margin: 0.1px;
                 ">
-                <a style="color: #5a5a5a;" href="callto:{{ data["formatted_phone"] | e}}">{{ data["formatted_phone"] | e}}</a>
+                <a style="color: #5a5a5a;" href="tel:{{ data["formatted_phone"] | e}}">{{ data["formatted_phone"] | e}}</a>
               </p>
             </td>
           </tr>


### PR DESCRIPTION
This pull request includes a change to the `src/xebia_email_signature/templates/signature.html.jinja` file. The change wraps the `formatted_phone` data field in an anchor tag to create a clickable link for phone numbers in the email signature. This allows users to directly call the phone number by clicking on it.

Fixes: #52 